### PR TITLE
feat(jsx): improve compatibility with React 19 (precedence / specialbehavior / title)

### DIFF
--- a/src/jsx/dom/intrinsic-element/components.test.tsx
+++ b/src/jsx/dom/intrinsic-element/components.test.tsx
@@ -71,7 +71,7 @@ describe('intrinsic element', () => {
         expect(document.head.innerHTML).toBe('<title>Document Title 1</title>')
       })
 
-      it('should be preserved when unmounted', async () => {
+      it('should be removed when unmounted', async () => {
         const App = () => {
           const [count, setCount] = useState(0)
           return (
@@ -91,7 +91,58 @@ describe('intrinsic element', () => {
         expect(root.innerHTML).toBe('<div><div>1</div><button>+</button></div>')
         root.querySelector('button')?.click()
         await Promise.resolve()
+        expect(document.head.innerHTML).toBe('')
+        expect(root.innerHTML).toBe('<div><div>2</div><button>+</button></div>')
+      })
+
+      it('should be inserted bottom of head if existing element is removed', async () => {
+        document.head.innerHTML = '<title>Existing Title</title>'
+
+        const App = () => {
+          const [count, setCount] = useState(0)
+          return (
+            <div>
+              {count === 1 && <title>Document Title {count}</title>}
+              <div>{count}</div>
+              <button onClick={() => setCount(count + 1)}>+</button>
+            </div>
+          )
+        }
+        render(<App />, root)
+        expect(document.head.innerHTML).toBe('<title>Existing Title</title>')
+        expect(root.innerHTML).toBe('<div><div>0</div><button>+</button></div>')
+        root.querySelector('button')?.click()
+        document.head.querySelector('title')?.remove()
+        await Promise.resolve()
         expect(document.head.innerHTML).toBe('<title>Document Title 1</title>')
+        expect(root.innerHTML).toBe('<div><div>1</div><button>+</button></div>')
+      })
+
+      it('should be inserted before existing title element', async () => {
+        document.head.innerHTML = '<title>Existing Title</title>'
+
+        const App = () => {
+          const [count, setCount] = useState(0)
+          return (
+            <div>
+              {count === 1 && <title>Document Title {count}</title>}
+              <div>{count}</div>
+              <button onClick={() => setCount(count + 1)}>+</button>
+            </div>
+          )
+        }
+        render(<App />, root)
+        expect(document.head.innerHTML).toBe('<title>Existing Title</title>')
+        expect(root.innerHTML).toBe('<div><div>0</div><button>+</button></div>')
+        root.querySelector('button')?.click()
+        await Promise.resolve()
+        expect(document.head.innerHTML).toBe(
+          '<title>Document Title 1</title><title>Existing Title</title>'
+        )
+        expect(root.innerHTML).toBe('<div><div>1</div><button>+</button></div>')
+        root.querySelector('button')?.click()
+        await Promise.resolve()
+        expect(document.head.innerHTML).toBe('<title>Existing Title</title>')
         expect(root.innerHTML).toBe('<div><div>2</div><button>+</button></div>')
       })
     })

--- a/src/jsx/intrinsic-element/common.ts
+++ b/src/jsx/intrinsic-element/common.ts
@@ -1,9 +1,11 @@
 export const deDupeKeys: Record<string, string[]> = {
   title: [],
   script: ['src'],
-  style: ['href'],
+  style: ['data-href'],
   link: ['href'],
   meta: ['name', 'httpEquiv', 'charset', 'itemProp'],
 }
 
 export const domRenderers: Record<string, Function> = {}
+
+export const dataPrecedenceAttr = 'data-precedence'

--- a/src/jsx/intrinsic-element/common.ts
+++ b/src/jsx/intrinsic-element/common.ts
@@ -1,4 +1,4 @@
-export const deDupeKeys: Record<string, string[]> = {
+export const deDupeKeyMap: Record<string, string[]> = {
   title: [],
   script: ['src'],
   style: ['data-href'],


### PR DESCRIPTION
* ea5b9eb5a232df16a8df466862c09cdea589c09a
    * The precedence attribute is actually written out to the DOM as data-precedence
    * The href attribute of the style element is actually written to the DOM as data-href
    * If the element has a disabled attribute, write out the element with the disabled attribute instead of deleting it.
    * Implement the [Special rendering behavior](https://react.dev/reference/react-dom/components/link#special-rendering-behavior) correctly
* 3f513ff1d9ebbdd21049a97407c04a056e799dad
    * In React 19, when multiple title elements are added, they are added on top of each other without being dedupe, so that the same behaviour is achieved.